### PR TITLE
Build as DLL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.0)
 project(hiredis)
 
 option(HIREDIS_BUILD_SHARED "Build a shared library." OFF)
+option(HIREDIS_BUILD_EXAMPLE "Build the example program." OFF)
+option(HIREDIS_BUILD_TEST "Build the test program." OFF)
 
 set(SOURCES async.c hiredis.c net.c sds.c)
 
@@ -44,4 +46,14 @@ add_library(hiredis ${SOURCES})
 
 if(HIREDIS_BUILD_SHARED)
   target_compile_definitions(hiredis PRIVATE -DHIREDIS_BUILD_SHARED)
+endif()
+
+if(HIREDIS_BUILD_EXAMPLE)
+  add_executable(hiredis_example examples/example.c)
+  target_link_libraries(hiredis_example hiredis)
+endif()
+
+if(HIREDIS_BUILD_TEST)
+  add_executable(hiredis_test test.c)
+  target_link_libraries(hiredis_test hiredis)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.0)
+project(hiredis)
+
+option(HIREDIS_BUILD_SHARED "Build a shared library." OFF)
+
+set(SOURCES async.c hiredis.c net.c sds.c)
+
+include_directories(.)
+
+if(WIN32)
+  set (WIN32_INTEROP_SOURCES
+       msvs/win32_interop/win32_common.cpp
+       msvs/win32_interop/win32_fixes.c
+       msvs/win32_interop/win32_ANSI.c
+       msvs/win32_interop/win32_APIs.c
+       msvs/win32_interop/win32_error.c
+       msvs/win32_interop/win32_fdapi.cpp
+       msvs/win32_interop/win32_fdapi_crt.cpp
+       msvs/win32_interop/win32_rfdmap.cpp
+       msvs/win32_interop/win32_variadic_functor.cpp
+       msvs/win32_interop/win32_wsiocp.c)
+
+  set (SOURCES ${SOURCES}
+       ${WIN32_INTEROP_SOURCES}
+       msvs/deps/adlist.c
+       msvs/deps/ae.c)
+
+  include_directories(msvs/deps msvs/win32_interop)
+
+  # no "unsafe" warnings for _snprintf
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+
+  # some flags only for win32_interop sources
+  set_source_files_properties(${WIN32_INTEROP_SOURCES} PROPERTIES COMPILE_FLAGS "-DUNICODE -DPSAPI_VERSION=1")
+endif()
+
+if(HIREDIS_BUILD_SHARED)
+  set(BUILD_SHARED_LIBS ON)
+else()
+  set(BUILD_SHARED_LIBS OFF)
+endif()
+
+add_library(hiredis ${SOURCES})
+
+if(HIREDIS_BUILD_SHARED)
+  target_compile_definitions(hiredis PRIVATE -DHIREDIS_BUILD_SHARED)
+endif()

--- a/async.h
+++ b/async.h
@@ -101,27 +101,27 @@ typedef struct redisAsyncContext {
 } redisAsyncContext;
 
 /* Functions that proxy to hiredis */
-redisAsyncContext *redisAsyncConnect(const char *ip, int port);
-redisAsyncContext *redisAsyncConnectBind(const char *ip, int port, const char *source_addr);
-redisAsyncContext *redisAsyncConnectUnix(const char *path);
-int redisAsyncSetConnectCallback(redisAsyncContext *ac, redisConnectCallback *fn);
-int redisAsyncSetDisconnectCallback(redisAsyncContext *ac, redisDisconnectCallback *fn);
-void redisAsyncDisconnect(redisAsyncContext *ac);
-void redisAsyncFree(redisAsyncContext *ac);
+HIREDIS_API redisAsyncContext *redisAsyncConnect(const char *ip, int port);
+HIREDIS_API redisAsyncContext *redisAsyncConnectBind(const char *ip, int port, const char *source_addr);
+HIREDIS_API redisAsyncContext *redisAsyncConnectUnix(const char *path);
+HIREDIS_API int redisAsyncSetConnectCallback(redisAsyncContext *ac, redisConnectCallback *fn);
+HIREDIS_API int redisAsyncSetDisconnectCallback(redisAsyncContext *ac, redisDisconnectCallback *fn);
+HIREDIS_API void redisAsyncDisconnect(redisAsyncContext *ac);
+HIREDIS_API void redisAsyncFree(redisAsyncContext *ac);
 
 /* Handle read/write events */
-void redisAsyncHandleRead(redisAsyncContext *ac);
-void redisAsyncHandleWrite(redisAsyncContext *ac);
+HIREDIS_API void redisAsyncHandleRead(redisAsyncContext *ac);
+HIREDIS_API void redisAsyncHandleWrite(redisAsyncContext *ac);
 #ifdef _WIN32
-int redisAsyncHandleWritePrep(redisAsyncContext *ac);
-int redisAsyncHandleWriteComplete(redisAsyncContext *ac, int written);
+HIREDIS_API int redisAsyncHandleWritePrep(redisAsyncContext *ac);
+HIREDIS_API int redisAsyncHandleWriteComplete(redisAsyncContext *ac, int written);
 #endif
 
 /* Command functions for an async context. Write the command to the
  * output buffer and register the provided callback. */
-int redisvAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, va_list ap);
-int redisAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, ...);
-int redisAsyncCommandArgv(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, int argc, const char **argv, const size_t *argvlen);
+HIREDIS_API int redisvAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, va_list ap);
+HIREDIS_API int redisAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, ...);
+HIREDIS_API int redisAsyncCommandArgv(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, int argc, const char **argv, const size_t *argvlen);
 
 #ifdef __cplusplus
 }

--- a/examples/example.c
+++ b/examples/example.c
@@ -4,6 +4,14 @@
 
 #include <hiredis.h>
 
+// collisions with winsock2.h make it difficult to define this anywhere
+#ifdef _WIN32
+struct timeval {
+  long    tv_sec;         /* seconds */
+  long    tv_usec;        /* and microseconds */
+};
+#endif
+
 int main(int argc, char **argv) {
     unsigned int j;
     redisContext *c;

--- a/hiredis.h
+++ b/hiredis.h
@@ -43,6 +43,16 @@
 #define HIREDIS_MINOR 11
 #define HIREDIS_PATCH 0
 
+/* mark API methods for dll export if requested */
+#if defined(_WIN32) && defined(HIREDIS_BUILD_SHARED)
+#define HIREDIS_API __declspec(dllexport)
+#elif defined(_WIN32) && defined(HIREDIS_USE_SHARED)
+/* not required, only for optimization */
+#define HIREDIS_API __declspec(dllimport)
+#else
+#define HIREDIS_API
+#endif
+
 #define REDIS_ERR -1
 #define REDIS_OK 0
 
@@ -144,10 +154,10 @@ typedef struct redisReader {
 } redisReader;
 
 /* Public API for the protocol parser. */
-redisReader *redisReaderCreate(void);
-void redisReaderFree(redisReader *r);
-int redisReaderFeed(redisReader *r, const char *buf, size_t len);
-int redisReaderGetReply(redisReader *r, void **reply);
+HIREDIS_API redisReader *redisReaderCreate(void);
+HIREDIS_API void redisReaderFree(redisReader *r);
+HIREDIS_API int redisReaderFeed(redisReader *r, const char *buf, size_t len);
+HIREDIS_API int redisReaderGetReply(redisReader *r, void **reply);
 
 /* Backwards compatibility, can be removed on big version bump. */
 #define redisReplyReaderCreate redisReaderCreate
@@ -159,12 +169,12 @@ int redisReaderGetReply(redisReader *r, void **reply);
 #define redisReplyReaderGetError(_r) (((redisReader*)(_r))->errstr)
 
 /* Function to free the reply objects hiredis returns by default. */
-void freeReplyObject(void *reply);
+HIREDIS_API void freeReplyObject(void *reply);
 
 /* Functions to format a command according to the protocol. */
-int redisvFormatCommand(char **target, const char *format, va_list ap);
-int redisFormatCommand(char **target, const char *format, ...);
-int redisFormatCommandArgv(char **target, int argc, const char **argv, const size_t *argvlen);
+HIREDIS_API int redisvFormatCommand(char **target, const char *format, va_list ap);
+HIREDIS_API int redisFormatCommand(char **target, const char *format, ...);
+HIREDIS_API int redisFormatCommandArgv(char **target, int argc, const char **argv, const size_t *argvlen);
 
 /* Context for a connection to Redis */
 typedef struct redisContext {
@@ -176,46 +186,46 @@ typedef struct redisContext {
     redisReader *reader; /* Protocol reader */
 } redisContext;
 
-redisContext *redisConnect(const char *ip, int port);
-redisContext *redisConnectWithTimeout(const char *ip, int port, const struct timeval tv);
-redisContext *redisConnectNonBlock(const char *ip, int port);
-redisContext *redisConnectBindNonBlock(const char *ip, int port, const char *source_addr);
-redisContext *redisConnectUnix(const char *path);
-redisContext *redisConnectUnixWithTimeout(const char *path, const struct timeval tv);
-redisContext *redisConnectUnixNonBlock(const char *path);
-redisContext *redisConnectFd(int fd);
-int redisSetTimeout(redisContext *c, const struct timeval tv);
-int redisEnableKeepAlive(redisContext *c);
-void redisFree(redisContext *c);
-int redisFreeKeepFd(redisContext *c);
-int redisBufferRead(redisContext *c);
-int redisBufferWrite(redisContext *c, int *done);
+HIREDIS_API redisContext *redisConnect(const char *ip, int port);
+HIREDIS_API redisContext *redisConnectWithTimeout(const char *ip, int port, const struct timeval tv);
+HIREDIS_API redisContext *redisConnectNonBlock(const char *ip, int port);
+HIREDIS_API redisContext *redisConnectBindNonBlock(const char *ip, int port, const char *source_addr);
+HIREDIS_API redisContext *redisConnectUnix(const char *path);
+HIREDIS_API redisContext *redisConnectUnixWithTimeout(const char *path, const struct timeval tv);
+HIREDIS_API redisContext *redisConnectUnixNonBlock(const char *path);
+HIREDIS_API redisContext *redisConnectFd(int fd);
+HIREDIS_API int redisSetTimeout(redisContext *c, const struct timeval tv);
+HIREDIS_API int redisEnableKeepAlive(redisContext *c);
+HIREDIS_API void redisFree(redisContext *c);
+HIREDIS_API int redisFreeKeepFd(redisContext *c);
+HIREDIS_API int redisBufferRead(redisContext *c);
+HIREDIS_API int redisBufferWrite(redisContext *c, int *done);
 
 /* In a blocking context, this function first checks if there are unconsumed
  * replies to return and returns one if so. Otherwise, it flushes the output
  * buffer to the socket and reads until it has a reply. In a non-blocking
  * context, it will return unconsumed replies until there are no more. */
-int redisGetReply(redisContext *c, void **reply);
-int redisGetReplyFromReader(redisContext *c, void **reply);
+HIREDIS_API int redisGetReply(redisContext *c, void **reply);
+HIREDIS_API int redisGetReplyFromReader(redisContext *c, void **reply);
 
 /* Write a formatted command to the output buffer. Use these functions in blocking mode
  * to get a pipeline of commands. */
-int redisAppendFormattedCommand(redisContext *c, const char *cmd, size_t len);
+HIREDIS_API int redisAppendFormattedCommand(redisContext *c, const char *cmd, size_t len);
 
 /* Write a command to the output buffer. Use these functions in blocking mode
  * to get a pipeline of commands. */
-int redisvAppendCommand(redisContext *c, const char *format, va_list ap);
-int redisAppendCommand(redisContext *c, const char *format, ...);
-int redisAppendCommandArgv(redisContext *c, int argc, const char **argv, const size_t *argvlen);
+HIREDIS_API int redisvAppendCommand(redisContext *c, const char *format, va_list ap);
+HIREDIS_API int redisAppendCommand(redisContext *c, const char *format, ...);
+HIREDIS_API int redisAppendCommandArgv(redisContext *c, int argc, const char **argv, const size_t *argvlen);
 
 /* Issue a command to Redis. In a blocking context, it is identical to calling
  * redisAppendCommand, followed by redisGetReply. The function will return
  * NULL if there was an error in performing the request, otherwise it will
  * return the reply. In a non-blocking context, it is identical to calling
  * only redisAppendCommand and will always return NULL. */
-void *redisvCommand(redisContext *c, const char *format, va_list ap);
-void *redisCommand(redisContext *c, const char *format, ...);
-void *redisCommandArgv(redisContext *c, int argc, const char **argv, const size_t *argvlen);
+HIREDIS_API void *redisvCommand(redisContext *c, const char *format, va_list ap);
+HIREDIS_API void *redisCommand(redisContext *c, const char *format, ...);
+HIREDIS_API void *redisCommandArgv(redisContext *c, int argc, const char **argv, const size_t *argvlen);
 
 #ifdef __cplusplus
 }

--- a/test.c
+++ b/test.c
@@ -7,7 +7,8 @@
 #include <sys/time.h>
 #else
 #include <WinSock2.h>
-#include "../../src/Win32_Interop/Win32_Time.h"
+#include <sys/types.h>
+#include <sys/timeb.h>
 #endif
 #include <assert.h>
 #ifndef _WIN32
@@ -23,6 +24,9 @@
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
 #define SIGPIPE 13
+#define IF_WIN32(yes, no) yes
+#else
+#define IF_WIN32(yes, no) no
 #endif
 
 
@@ -52,9 +56,15 @@ static int tests = 0, fails = 0;
 #define test_cond(_c) if(_c) printf("\033[0;32mPASSED\033[0;0m\n"); else {printf("\033[0;31mFAILED\033[0;0m\n"); fails++;}
 
 static long long usec(void) {
+#ifdef _WIN32
+    struct __timeb64 tb;
+    _ftime64_s(&tb);
+    return (((long long)tb.time) * 1000000) + (tb.millitm * 1000);
+#else
     struct timeval tv;
     gettimeofday(&tv,NULL);
     return (((long long)tv.tv_sec)*1000000)+tv.tv_usec;
+#endif
 }
 
 static redisContext *select_database(redisContext *c) {


### PR DESCRIPTION
The Windows port of hiredis defines and exports a few symbols that conflict with ws2_32.lib (winsock2), leading to linker errors if both the hiredis static lib and the winsock DLL are linked in. This is also described in the open issue #5.

I order to avoid the conflicts, I added the option to build hiredis as a DLL which only exports the required API functions.

I've also added CMake build configuration to test/use my changes, although I don't have any experience with CMake so it might not be very good, and I don't know if you'd even want it.